### PR TITLE
fix compiler error and 120 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(pntr
     LANGUAGES C
 )
 
+set(C_STANDARD 99)
+
 # pntr
 add_library(pntr INTERFACE)
 target_include_directories(pntr INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -23,6 +25,8 @@ option(PNTR_BUILD_TESTS "TESTS" ${PNTR_IS_MAIN})
 if (PNTR_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
+
+
 
 # Tests
 if (PNTR_BUILD_TESTS)

--- a/examples/pntr_sdl_example.c
+++ b/examples/pntr_sdl_example.c
@@ -1,5 +1,5 @@
 #include <stdbool.h>
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 #define PNTR_IMPLEMENTATION
 #include "../pntr.h"

--- a/examples/pntr_sdl_example.c
+++ b/examples/pntr_sdl_example.c
@@ -1,5 +1,5 @@
 #include <stdbool.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #define PNTR_IMPLEMENTATION
 #include "../pntr.h"

--- a/pntr.h
+++ b/pntr.h
@@ -601,14 +601,16 @@ pntr_image* pntr_image_resize(pntr_image* image, int width, int height, pntr_fil
     }
 
     pntr_image* output = pntr_new_image(width, height);
+    int xRatio, yRatio;
+    int x2, y2;
 
     switch (filter) {
         case PNTR_FILTER_NEARESTNEIGHBOR:
         default:
-            int xRatio = (image->width << 16) / width + 1;
-            int yRatio = (image->height << 16) / height + 1;
+            xRatio = (image->width << 16) / width + 1;
+            yRatio = (image->height << 16) / height + 1;
 
-            int x2, y2;
+
             for (int y = 0; y < height; y++) {
                 for (int x = 0; x < width; x++) {
                     x2 = (x * xRatio) >> 16;

--- a/pntr.h
+++ b/pntr.h
@@ -175,6 +175,12 @@ extern "C" {
 #define PNTR_MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wconversion"
+
 // stb_image
 // TODO: Allow selective inclusion with stb_image. And use STBI_NO_STDIO
 #ifndef STBI_INCLUDE_STB_IMAGE_H
@@ -187,6 +193,8 @@ extern "C" {
 #define STB_IMAGE_IMPLEMENTATION
 #include "external/stb_image.h"
 #endif  // STBI_INCLUDE_STB_IMAGE_H
+
+#pragma GCC diagnostic pop
 
 const char* pntr_error;
 


### PR DESCRIPTION
I was getting this error on my compiler:

```
In file included from /Users/konsumer/Desktop/otherdev/pntr/examples/pntr_sdl_example.c:5:
/Users/konsumer/Desktop/otherdev/pntr/examples/../pntr.h:608:13: error: expected expression
            int xRatio = (image->width << 16) / width + 1;
            ^
/Users/konsumer/Desktop/otherdev/pntr/examples/../pntr.h:614:31: error: use of undeclared identifier 'xRatio'; did you mean 'yRatio'?
                    x2 = (x * xRatio) >> 16;
                              ^~~~~~
                              yRatio
/Users/konsumer/Desktop/otherdev/pntr/examples/../pntr.h:609:17: note: 'yRatio' declared here
            int yRatio = (image->height << 16) / height + 1;
```

I think it doesn't like defining vars inside the `case` or something. this resolves it.