### PR TITLE
wasm support and instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Work in progress.
 
 ![pntr: Examples - raylib Screenshot](examples/pntr_examples_raylib.png)
 
+```
+# setup for native build
+cmake -B build
+
+# build library and native demos
+cmake --build build
+
+# build web-demo
+emcc examples/pntr_examples_sdl.c -DPLATFORM_WEB -sUSE_SDL=2 -o build/index.html --preload-file examples/resources@/resources
+```
+
+
 ## License
 
 [Zlib](LICENSE)

--- a/examples/pntr_examples_sdl.c
+++ b/examples/pntr_examples_sdl.c
@@ -4,56 +4,76 @@
 // Load pntr and the examples
 #include "examples/examples.h"
 
-int main() {
-    // Initialize
-    examples_init();
+// this is just for web demo
+#ifdef __EMSCRIPTEN__
+    #include <emscripten.h>
+#endif
 
-    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS);
-    SDL_Window* window = SDL_CreateWindow("pntr: Examples - SDL", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, examples_width(), examples_height(), SDL_WINDOW_SHOWN);
-    SDL_Surface* screen = SDL_GetWindowSurface(window);
-    SDL_Surface* surface = SDL_CreateRGBSurfaceWithFormatFrom(examples_data(), examples_width(), examples_height(), 8, examples_pitch(), SDL_PIXELFORMAT_ARGB8888);
+SDL_Window *window;
+SDL_Renderer *screen;
+SDL_Surface *surface;
+
+bool shouldClose = false;
+
+void mainloop() {
     SDL_Event event;
-
-    bool shouldClose = false;
-    while (!shouldClose) {
-
-        while (SDL_PollEvent(&event) != 0) {
-            switch (event.type) {
-                case SDL_QUIT:
-                    shouldClose = true;
-                    break;
-                case SDL_MOUSEBUTTONUP:
-                    examples_next();
-                    break;
-                case SDL_KEYUP:
-                    switch (event.key.keysym.sym) {
-                        case SDLK_ESCAPE:
-                            shouldClose = true;
-                            break;
-                        case SDLK_LEFT:
-                            examples_previous();
-                            break;
-                        case SDLK_RIGHT:
-                        case SDLK_SPACE:
-                            examples_next();
-                            break;
-                    }
-                    break;
-            }
+    while (SDL_PollEvent(&event) != 0) {
+        switch (event.type) {
+            case SDL_QUIT:
+                shouldClose = true;
+                break;
+            case SDL_MOUSEBUTTONUP:
+                examples_next();
+                break;
+            case SDL_KEYUP:
+                switch (event.key.keysym.sym) {
+                    case SDLK_ESCAPE:
+                        shouldClose = true;
+                        break;
+                    case SDLK_LEFT:
+                        examples_previous();
+                        break;
+                    case SDLK_RIGHT:
+                    case SDLK_SPACE:
+                        examples_next();
+                        break;
+                }
+                break;
         }
+    }
 
+    if (shouldClose) {
+        SDL_FreeSurface(surface);
+
+        // Unload
+        examples_unload();
+
+        SDL_DestroyWindow(window);
+        SDL_Quit();
+    } else {
         // Update
         examples_update();
 
         SDL_BlitSurface(surface, NULL, screen, NULL);
         SDL_UpdateWindowSurface(window);
     }
+}
 
-    SDL_FreeSurface(surface);
+int main() {
+    // Initialize
+    examples_init();
 
-    // Unload
-    examples_unload();
+    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS);
+    window = SDL_CreateWindow("pntr: Examples - SDL", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, examples_width(), examples_height(), SDL_WINDOW_SHOWN);
+    screen = SDL_GetWindowSurface(window);
+    surface = SDL_CreateRGBSurfaceWithFormatFrom(examples_data(), examples_width(), examples_height(), 8, examples_pitch(), SDL_PIXELFORMAT_ARGB8888);
 
-    SDL_DestroyWindow(window);
-    SDL_Quit();
+    #ifdef __EMSCRIPTEN__
+        emscripten_set_main_loop(mainloop, 0, 1);
+    #else
+        while(!shouldClose) {
+            mainloop();
+            SDL_Delay(16);
+        }
+    #endif
 }


### PR DESCRIPTION
This retrofits the SDL demo with emscripten support, and adds instructions for all the builds in README (which just helps me remember how to build it.)