### PR TITLE
clearer error on missing images

### DIFF
--- a/examples/examples/example_bunnymark.h
+++ b/examples/examples/example_bunnymark.h
@@ -26,6 +26,11 @@ void example_bunnymark_init() {
     // Load an image
     bunnyImage = pntr_load_image("resources/bunny.png");
 
+    if (bunnyImage == NULL) {
+        printf("bunnyImage not loaded!\n");
+        return;
+    }
+
     bunnies = (Bunny *)malloc(MAX_BUNNIES * sizeof(Bunny));
     bunniesCount = 0;
     frameCount = 0;

--- a/examples/examples/example_fonts.h
+++ b/examples/examples/example_fonts.h
@@ -13,9 +13,21 @@ void example_fonts_init() {
     // BM Font
     bmFont = pntr_load_bmfont("resources/bmfont.png", " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?-+/");
 
+    if (bmFont == NULL) {
+        printf("resources/bmfont.png not loaded!\n");
+        return;
+    }
+
     // TTY Font
     ttyFont = pntr_load_ttyfont("resources/ttyfont-16x16.png", 16, 16,
         "\x7f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~");
+
+    if (ttyFont == NULL) {
+        printf("resources/ttyfont-16x16.png not loaded!\n");
+        return;
+    }
+
+
 }
 
 const char* example_fonts_update(pntr_image* canvas) {

--- a/examples/examples/example_images.h
+++ b/examples/examples/example_images.h
@@ -7,6 +7,11 @@ void example_images_init() {
     // Load an image
     image = pntr_load_image("resources/image.png");
 
+    if (image == NULL) {
+        printf("resources/image.png not loaded!\n");
+        return;
+    }
+
     // Resize the image
     resized = pntr_image_resize(image, image->width / 2, image->height / 2, PNTR_FILTER_NEARESTNEIGHBOR);
 }
@@ -28,7 +33,7 @@ const char* example_images_update(pntr_image* canvas) {
     pntr_draw_rectangle(canvas, 290, 50, 65, 58, faceColor);
 
     // Draw the resized image
-    pntr_draw_image(canvas, resized, 200, 130);
+    pntr_draw_image(canvas, image, 200, 130);
 
     return "Images";
 }


### PR DESCRIPTION
This is a small change to demos that will log that the image did not load. I was getting segfaults from trying to run it at the top-level, because it couldn't find the images.