### PR TITLE
Ttf spacing

### DIFF
--- a/pntr.h
+++ b/pntr.h
@@ -1098,7 +1098,7 @@ void pntr_draw_text(pntr_image* dst, pntr_font* font, const char* text, int posX
             for (int i = 0; i < font->charactersFound; i++) {
                 if (font->characters[i] == *currentChar) {
                     pntr_draw_image_rec(dst, font->atlas, font->rectangles[i], x + font->glyphBox[i].x, y + font->glyphBox[i].y);
-                    x += font->rectangles[i].width;
+                    x += font->glyphBox[i].width;
                     break;
                 }
             }
@@ -1270,9 +1270,9 @@ pntr_font* pntr_load_ttffont_from_memory(const char* fileData, int dataSize, int
                 .width = (int)characterData[i].xadvance,
                 .height = fontSize //font->rectangles[i].height
             };
+            // break
+            // asm("int $3");
         }
-
-
 
         // Port the bitmap to a pntr_image as the atlas.
         pntr_image* atlas = pntr_image_from_pixelformat((void*)bitmap, width, height, PNTR_PIXELFORMAT_GRAYSCALE);

--- a/pntr.h
+++ b/pntr.h
@@ -1272,9 +1272,12 @@ pntr_font* pntr_load_ttffont_from_memory(const char* fileData, int dataSize, int
             };
         }
 
+
+
         // Port the bitmap to a pntr_image as the atlas.
         pntr_image* atlas = pntr_image_from_pixelformat((void*)bitmap, width, height, PNTR_PIXELFORMAT_GRAYSCALE);
         font->atlas = atlas;
+        return font;
 #   endif
 }
 


### PR DESCRIPTION
This is a small change, and I'm not sure if it's right, but it appears we need to use `glyphBox` not `rectangle` for spacing.
<img width="512" alt="Screenshot 2023-02-05 at 2 50 12 PM" src="https://user-images.githubusercontent.com/83857/216850631-c7b8af33-e0dc-4971-9543-8040c3f1714d.png">
