### PR TITLE
Disable math by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add these defines prior to including `pntr.h` to modify how it functions.
 | `PNTR_ENABLE_DEFAULT_FONT` | Enables the default font |
 | `PNTR_ENABLE_TTF` | Enables TTF font loading |
 | `PNTR_DISABLE_ALPHABLEND` | Skips alpha blending when rendering images |
-| `PNTR_DISABLE_MATH` | Disables dependency on C's math.h library |
+| `PNTR_ENABLE_MATH` | Enables use of C's standard math.h library, rather than using the built in math functions |
 | `PNTR_LOAD_FILE` | Callback to use when asked to load a file in `pntr_load_file()`. By default, will use `stdio.h`. |
 | `PNTR_SAVE_FILE` | Callback to use when asked to save a file in `pntr_save_file()`. By default, will use `stdio.h`. |
 | `PNTR_LOAD_IMAGE_FROM_MEMORY` | Callback to use when loading an image from memory in `pntr_load_image_from_memory()`. By default, will use  [cute_png](https://github.com/RandyGaul/cute_headers/blob/master/cute_png.h) |

--- a/examples/pntr_examples.c
+++ b/examples/pntr_examples.c
@@ -1,10 +1,7 @@
 #define PNTR_ENABLE_DEFAULT_FONT
 #define PNTR_ENABLE_TTF
 #define PNTR_ENABLE_VARGS
-
 #define PNTR_ENABLE_MATH
-//#define PNTR_DISABLE_MATH
-
 #define PNTR_APP_IMPLEMENTATION
 #include "pntr_app.h"
 

--- a/extensions/pntr_stb_image.h
+++ b/extensions/pntr_stb_image.h
@@ -22,7 +22,7 @@ pntr_image* pntr_stb_image_load_image_from_memory(pntr_image_type type, const un
     #define STBI_NO_STDIO
     #define STBI_NO_SIMD
     #ifndef PNTR_ENABLE_JPEG
-    #define STBI_NO_JPEG // JPG support in stb_image.
+        #define STBI_NO_JPEG // JPG support in stb_image.
     #endif
     //#define STBI_NO_PNG
     #define STBI_NO_BMP
@@ -34,6 +34,8 @@ pntr_image* pntr_stb_image_load_image_from_memory(pntr_image_type type, const un
     #define STBI_NO_PNM
     //#define STBI_SUPPORT_ZLIB
     #define STBI_NO_LINEAR
+
+    #define STBI_ASSERT(x)
 #endif  // PNTR_NO_STB_IMAGE_IMPLEMENTATION
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/extensions/pntr_stb_image_write.h
+++ b/extensions/pntr_stb_image_write.h
@@ -19,6 +19,7 @@ unsigned char* pntr_stb_image_save_image_to_memory(pntr_image* image, pntr_image
     #define STBIW_FREE PNTR_FREE
     #define STBIW_MEMMOVE PNTR_MEMMOVE
     #define STBI_WRITE_NO_STDIO
+    #define STBIW_ASSERT(x)
 #endif  // PNTR_NO_STB_IMAGE_IMPLEMENTATION
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(pntr_test pntr_test.c)
 target_compile_options(pntr_test PRIVATE -Wall -Wextra -Wconversion -Wsign-conversion)
 target_link_libraries(pntr_test PUBLIC
     pntr
-    m
+    #m
 )
 set_property(TARGET pntr_test PROPERTY C_STANDARD 99)
 

--- a/test/pntr_test.c
+++ b/test/pntr_test.c
@@ -4,7 +4,6 @@
 
 #define PNTR_ENABLE_DEFAULT_FONT
 #define PNTR_ENABLE_TTF
-//#define PNTR_DISABLE_MATH
 
 #define PNTR_IMPLEMENTATION
 #include "../pntr.h"
@@ -478,21 +477,15 @@ MODULE(pntr, {
             pntr_unload_image(rotated);
         });
 
-        #ifndef PNTR_DISABLE_MATH
-            IT("pntr_image_rotate(image, 48.0f)", {
-                pntr_image* rotated = pntr_image_rotate(image, 48.0f, PNTR_FILTER_BILINEAR);
-                NEQUALS(rotated, NULL);
-                NEQUALS(rotated->width, image->height);
-                NEQUALS(rotated->height, image->width);
-                COLOREQUALS(pntr_image_get_color(rotated, 5, 5), PNTR_BLANK);
-                COLOREQUALS(pntr_image_get_color(rotated, rotated->width / 2, rotated->height / 2), PNTR_BLUE);
-                pntr_unload_image(rotated);
-            });
-        #else
-            IT("pntr_image_rotate(image, 48.0f): PNTR_DISABLE_MATH is defined, unable to test.", {
-                // Nothing
-            });
-        #endif  // PNTR_DISABLE_MATH
+        IT("pntr_image_rotate(image, 48.0f)", {
+            pntr_image* rotated = pntr_image_rotate(image, 48.0f, PNTR_FILTER_BILINEAR);
+            NEQUALS(rotated, NULL);
+            NEQUALS(rotated->width, image->height);
+            NEQUALS(rotated->height, image->width);
+            COLOREQUALS(pntr_image_get_color(rotated, 5, 5), PNTR_BLANK);
+            COLOREQUALS(pntr_image_get_color(rotated, rotated->width / 2, rotated->height / 2), PNTR_BLUE);
+            pntr_unload_image(rotated);
+        });
 
         IT("pntr_gen_image_gradient", {
             pntr_image* image = pntr_gen_image_gradient(500, 500, PNTR_RED, PNTR_GREEN, PNTR_BLUE, PNTR_GOLD);


### PR DESCRIPTION
Need to use `PNTR_ENABLE_MATH` to have it use math.h

Fixes #102