### PR TITLE
Fix arc/edge misalignment in pntr_draw_rectangle_thick_rounded

### DIFF
--- a/pntr.h
+++ b/pntr.h
@@ -3059,20 +3059,15 @@ PNTR_API void pntr_draw_rectangle_thick_rounded(pntr_image* dst, int x, int y, i
     if (thickness < 1) {
         return;
     }
-    if (thickness == 1) {
-        pntr_draw_rectangle_rounded(dst, x, y, width, height, topLeftRadius, topRightRadius, bottomLeftRadius, bottomRightRadius, color);
-        return;
+    for (int i = 0; i < thickness; i++) {
+        pntr_draw_rectangle_rounded(dst,
+            x + i, y + i, width - i * 2, height - i * 2,
+            topLeftRadius - i > 0 ? topLeftRadius - i : 0,
+            topRightRadius - i > 0 ? topRightRadius - i : 0,
+            bottomLeftRadius - i > 0 ? bottomLeftRadius - i : 0,
+            bottomRightRadius - i > 0 ? bottomRightRadius - i : 0,
+            color);
     }
-    for (int offset = 0; offset < thickness; offset++ ) {
-        pntr_draw_line_horizontal(dst, x + topLeftRadius - offset, y - offset, width - topLeftRadius - topRightRadius - offset, color); // Top
-        pntr_draw_line_horizontal(dst, x + bottomLeftRadius - offset, y + height - offset, width - bottomLeftRadius - bottomRightRadius - 1 - offset, color); // Bottom
-        pntr_draw_line_vertical(dst, x - offset, y + topLeftRadius - offset, height - topLeftRadius - bottomLeftRadius - offset, color); // Left
-        pntr_draw_line_vertical(dst, x + width - 1 - offset, y + topRightRadius - offset, height - topRightRadius - bottomRightRadius - offset, color); // Right
-    }
-    pntr_draw_arc_thick(dst, x + topLeftRadius, y + topLeftRadius, (float)topLeftRadius, 180.0f, 270.0f, topLeftRadius * 2, thickness, color); // Top Left
-    pntr_draw_arc_thick(dst, x + width - topRightRadius - 1, y + topRightRadius, (float)topRightRadius, 0.0f, -90.0f, topRightRadius * 2, thickness, color); // Top Right
-    pntr_draw_arc_thick(dst, x + bottomLeftRadius, y + height - bottomLeftRadius, (float)bottomLeftRadius, -180.0f, -270.0f, bottomLeftRadius * 2, thickness, color); // Bottom Left
-    pntr_draw_arc_thick(dst, x + width - bottomRightRadius - 1, y + height - bottomRightRadius, (float)bottomRightRadius, 0.0f, 90.0f, bottomRightRadius * 2, thickness, color); // Bottom Right
 }
 
 PNTR_API void pntr_draw_rectangle_rounded_fill(pntr_image* dst, int x, int y, int width, int height, int cornerRadius, pntr_color color) {


### PR DESCRIPTION
Fixes #199.

Replace the broken offset loop (which shifted straight edges inconsistently while leaving arcs fixed) with a simple loop that draws N concentric 1-pixel outlines via `pntr_draw_rectangle_rounded`, shrinking inward each iteration. This keeps arcs and straight edges perfectly aligned at every thickness.