### PR TITLE
Fix resize_canvas clip handling

### DIFF
--- a/pntr.h
+++ b/pntr.h
@@ -5277,6 +5277,10 @@ PNTR_API bool pntr_image_resize_canvas(pntr_image* image, int newWidth, int newH
 
     pntr_draw_image(newImage, image, offsetX, offsetY);
 
+    bool hadDefaultClip = (image->clip.x == 0 && image->clip.y == 0 &&
+        image->clip.width == image->width && image->clip.height == image->height);
+    pntr_rectangle oldClip = image->clip;
+
     // Clear the image if it's not a subimage
     if (!image->subimage) {
         PNTR_FREE(image->data);
@@ -5286,10 +5290,24 @@ PNTR_API bool pntr_image_resize_canvas(pntr_image* image, int newWidth, int newH
     image->width = newImage->width;
     image->height = newImage->height;
     image->pitch = newImage->pitch;
-
-    // TODO: pntr_image_resize_canvas - Adust the new image clip with the original one.
-    pntr_image_reset_clip(image);
     image->subimage = false;
+
+    if (hadDefaultClip) {
+        pntr_image_reset_clip(image);
+    } else {
+        int cx = oldClip.x + offsetX;
+        int cy = oldClip.y + offsetY;
+        int cx2 = cx + oldClip.width;
+        int cy2 = cy + oldClip.height;
+        if (cx < 0) cx = 0;
+        if (cy < 0) cy = 0;
+        if (cx2 > newWidth) cx2 = newWidth;
+        if (cy2 > newHeight) cy2 = newHeight;
+        image->clip.x = cx;
+        image->clip.y = cy;
+        image->clip.width = (cx2 > cx) ? cx2 - cx : 0;
+        image->clip.height = (cy2 > cy) ? cy2 - cy : 0;
+    }
 
     PNTR_FREE(newImage);
     return true;

--- a/test/pntr_test.c
+++ b/test/pntr_test.c
@@ -532,6 +532,17 @@ MODULE(pntr, {
         EQUALS(image->height, 400);
         COLOREQUALS(pntr_image_get_color(image, 50, 50), PNTR_RED);
         COLOREQUALS(pntr_image_get_color(image, 150, 150), PNTR_BLUE);
+        pntr_rectangle expectedClip = {0, 0, 400, 400};
+        RECTEQUALS(pntr_image_get_clip(image), expectedClip);
+        pntr_unload_image(image);
+    });
+
+    IT("pntr_image_resize_canvas() preserves custom clip", {
+        pntr_image* image = pntr_gen_image_color(200, 200, PNTR_BLUE);
+        pntr_image_set_clip(image, 10, 10, 50, 50);
+        pntr_image_resize_canvas(image, 300, 300, 20, 20, PNTR_RED);
+        pntr_rectangle expectedCustomClip = {30, 30, 50, 50};
+        RECTEQUALS(pntr_image_get_clip(image), expectedCustomClip);
         pntr_unload_image(image);
     });
 


### PR DESCRIPTION
Clamp and translate the existing clip rect when resizing the canvas instead of unconditionally resetting it. Adds a test for both default-clip and custom-clip cases. Fixes #208